### PR TITLE
Integrate Blur Bottom Sheet

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,11 +1,12 @@
 import * as React from "react";
 import { SQLiteProvider } from "expo-sqlite/next";
-import { ActivityIndicator, Text, View } from "react-native";
+import { ActivityIndicator, Platform, Text, View } from "react-native";
 import * as FileSystem from "expo-file-system";
 import { Asset } from "expo-asset";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { NavigationContainer } from "@react-navigation/native";
 import Home from "./screens/Home";
+import Payment from "./screens/sheets/Payment";
 
 const Stack = createNativeStackNavigator();
 
@@ -59,6 +60,18 @@ export default function App() {
               options={{
                 headerTitle: "Budget Buddy",
                 headerLargeTitle: true,
+                headerTransparent: Platform.OS === "ios" ? true : false,
+                headerBlurEffect: "light",
+              }}
+            />
+            <Stack.Screen
+              name="Payment"
+              component={Payment}
+              options={{
+                presentation: "transparentModal",
+                animation: "slide_from_bottom",
+                animationTypeForReplace: "pop",
+                headerShown: false,
               }}
             />
           </Stack.Navigator>

--- a/app.json
+++ b/app.json
@@ -5,23 +5,23 @@
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
-    "userInterfaceStyle": "light",
+    "userInterfaceStyle": "automatic",
     "splash": {
       "image": "./assets/splash.png",
       "resizeMode": "contain",
       "backgroundColor": "#ffffff"
     },
-    "assetBundlePatterns": [
-      "**/*"
-    ],
+    "assetBundlePatterns": ["**/*"],
     "ios": {
-      "supportsTablet": true
+      "supportsTablet": true,
+      "bundleIdentifier": "com.betomoedano.BudgetBuddy"
     },
     "android": {
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ffffff"
-      }
+      },
+      "package": "com.betomoedano.BudgetBuddy"
     },
     "web": {
       "favicon": "./assets/favicon.png"

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {
     "start": "expo start",
-    "android": "expo start --android",
-    "ios": "expo start --ios",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
     "web": "expo start --web"
   },
   "dependencies": {
@@ -14,9 +14,12 @@
     "@react-navigation/native-stack": "^6.9.18",
     "expo": "^50.0.7",
     "expo-asset": "~9.0.2",
+    "expo-blur": "~12.9.2",
     "expo-file-system": "~16.0.6",
     "expo-sqlite": "~13.2.2",
     "expo-status-bar": "~1.11.1",
+    "expo-symbols": "^0.1.4",
+    "expo-system-ui": "~2.9.4",
     "react": "18.2.0",
     "react-native": "0.73.4",
     "react-native-auto-size-text": "^1.1.1",

--- a/screens/Home.tsx
+++ b/screens/Home.tsx
@@ -1,12 +1,34 @@
 import * as React from "react";
-import { ScrollView, StyleSheet, Text, TextStyle, View } from "react-native";
+import {
+  Button,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextStyle,
+  TouchableHighlight,
+  TouchableOpacity,
+  TouchableWithoutFeedback,
+  View,
+} from "react-native";
 import { Category, Transaction, TransactionsByMonth } from "../types";
 import { useSQLiteContext } from "expo-sqlite/next";
 import TransactionList from "../components/TransactionsList";
 import Card from "../components/ui/Card";
 import AddTransaction from "../components/AddTransaction";
+import { BlurView } from "expo-blur";
+import { SymbolView } from "expo-symbols";
+import { useNavigation } from "@react-navigation/native";
+import { NativeStackNavigationProp } from "@react-navigation/native-stack";
+
+type StackParamList = {
+  Payment: undefined;
+};
 
 export default function Home() {
+  const navigation =
+    useNavigation<NativeStackNavigationProp<StackParamList, "Payment">>();
   const [categories, setCategories] = React.useState<Category[]>([]);
   const [transactions, setTransactions] = React.useState<Transaction[]>([]);
   const [transactionsByMonth, setTransactionsByMonth] =
@@ -84,18 +106,64 @@ export default function Home() {
   }
 
   return (
-    <ScrollView contentContainerStyle={{ padding: 15, paddingVertical: 170 }}>
-      <AddTransaction insertTransaction={insertTransaction} />
-      <TransactionSummary
-        totalExpenses={transactionsByMonth.totalExpenses}
-        totalIncome={transactionsByMonth.totalIncome}
-      />
-      <TransactionList
-        categories={categories}
-        transactions={transactions}
-        deleteTransaction={deleteTransaction}
-      />
-    </ScrollView>
+    <>
+      <ScrollView
+        contentContainerStyle={{
+          padding: 15,
+          paddingVertical: Platform.OS === "ios" ? 170 : 16,
+        }}
+      >
+        <AddTransaction insertTransaction={insertTransaction} />
+        <TransactionSummary
+          totalExpenses={transactionsByMonth.totalExpenses}
+          totalIncome={transactionsByMonth.totalIncome}
+        />
+        <TransactionList
+          categories={categories}
+          transactions={transactions}
+          deleteTransaction={deleteTransaction}
+        />
+      </ScrollView>
+      <BlurView
+        experimentalBlurMethod="dimezisBlurView"
+        intensity={90}
+        tint={"light"}
+        style={styles.blur}
+      >
+        <View
+          style={{
+            flexDirection: "row",
+            justifyContent: "space-between",
+            alignItems: "center",
+          }}
+        >
+          <View>
+            <Text style={{ color: "gray" }}>Lifetime savings</Text>
+            <Text style={{ fontWeight: "bold", fontSize: 28 }}>
+              $123,823.50
+            </Text>
+          </View>
+          <TouchableOpacity
+            activeOpacity={0.8}
+            onPress={() => navigation.navigate("Payment")}
+          >
+            <SymbolView
+              size={48}
+              type="palette"
+              name="checkmark.circle"
+              colors={["black", "transparent"]}
+              style={{ backgroundColor: "#00000010", borderRadius: 50 }}
+              fallback={
+                <Button
+                  title="open"
+                  onPress={() => navigation.navigate("Payment")}
+                />
+              }
+            />
+          </TouchableOpacity>
+        </View>
+      </BlurView>
+    </>
   );
 }
 
@@ -122,33 +190,43 @@ function TransactionSummary({
   };
 
   return (
-    <Card style={styles.container}>
-      <Text style={styles.periodTitle}>Summary for {readablePeriod}</Text>
-      <Text style={styles.summaryText}>
-        Income:{" "}
-        <Text style={getMoneyTextStyle(totalIncome)}>
-          {formatMoney(totalIncome)}
+    <>
+      <Card style={styles.container}>
+        <Text style={styles.periodTitle}>Summary for {readablePeriod}</Text>
+        <Text style={styles.summaryText}>
+          Income:{" "}
+          <Text style={getMoneyTextStyle(totalIncome)}>
+            {formatMoney(totalIncome)}
+          </Text>
         </Text>
-      </Text>
-      <Text style={styles.summaryText}>
-        Total Expenses:{" "}
-        <Text style={getMoneyTextStyle(totalExpenses)}>
-          {formatMoney(totalExpenses)}
+        <Text style={styles.summaryText}>
+          Total Expenses:{" "}
+          <Text style={getMoneyTextStyle(totalExpenses)}>
+            {formatMoney(totalExpenses)}
+          </Text>
         </Text>
-      </Text>
-      <Text style={styles.summaryText}>
-        Savings:{" "}
-        <Text style={getMoneyTextStyle(savings)}>{formatMoney(savings)}</Text>
-      </Text>
-    </Card>
+        <Text style={styles.summaryText}>
+          Savings:{" "}
+          <Text style={getMoneyTextStyle(savings)}>{formatMoney(savings)}</Text>
+        </Text>
+      </Card>
+    </>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
-    marginBottom: 15,
+    marginBottom: 16,
     paddingBottom: 7,
-    // Add other container styles as necessary
+  },
+  blur: {
+    width: "100%",
+    height: 110,
+    position: "absolute",
+    bottom: 0,
+    borderTopWidth: 1,
+    borderTopColor: "#00000010",
+    padding: 16,
   },
   periodTitle: {
     fontSize: 20,

--- a/screens/sheets/Payment.tsx
+++ b/screens/sheets/Payment.tsx
@@ -1,0 +1,109 @@
+import { useNavigation } from "@react-navigation/native";
+import { BlurView } from "expo-blur";
+import {
+  Button,
+  Platform,
+  PlatformColor,
+  Pressable,
+  ScrollView,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+
+export default function Payment() {
+  const navigation = useNavigation();
+  return (
+    <View style={{ flex: 1 }}>
+      <Pressable style={{ flex: 1 }} onPress={() => navigation.goBack()}>
+        <View />
+      </Pressable>
+      <BlurView
+        experimentalBlurMethod="dimezisBlurView"
+        intensity={90}
+        tint="light"
+        style={{
+          height: "50%",
+          width: "100%",
+          position: "absolute",
+          bottom: 0,
+          elevation: 8,
+          shadowColor: "#000",
+          shadowRadius: 8,
+          shadowOpacity: 0.15,
+          padding: 16,
+        }}
+      >
+        <View
+          style={{
+            flexDirection: "row",
+            alignItems: "center",
+            justifyContent: "space-between",
+          }}
+        >
+          <Pressable onPress={() => navigation.goBack()}>
+            <Text style={{ color: "#007AFF", fontSize: 17 }}>Cancel</Text>
+          </Pressable>
+        </View>
+        <View style={{ gap: 10, paddingTop: 16 }}>
+          <Text
+            style={{
+              textAlign: "center",
+              fontSize: 28,
+              fontWeight: "bold",
+              color: "gray",
+            }}
+          >
+            Lifetime savings
+          </Text>
+          <Text
+            style={{
+              textAlign: "center",
+              fontSize: 32,
+              fontWeight: "900",
+              marginTop: 16,
+            }}
+          >
+            $123,823.50
+          </Text>
+          <Text style={{ textAlign: "center" }}>
+            Saving money is the first step on financial freedom, learn more
+            about how to invest your money at
+            <Text style={{ color: "#007AFF" }}> codewithbeto.dev</Text>
+          </Text>
+
+          <TouchableOpacity
+            activeOpacity={0.9}
+            style={{
+              backgroundColor: "black",
+              padding: 10,
+              borderRadius: 10,
+              marginTop: 16,
+            }}
+          >
+            <Text
+              style={{
+                fontWeight: "700",
+                fontSize: 17,
+                color: "white",
+                textAlign: "center",
+              }}
+            >
+              Get premium +
+            </Text>
+          </TouchableOpacity>
+
+          <Pressable onPress={() => navigation.goBack()}>
+            <Text style={{ color: "gray", fontSize: 17, textAlign: "center" }}>
+              Maybe later
+            </Text>
+          </Pressable>
+
+          <Text style={{ textAlign: "center", fontSize: 12, color: "gray" }}>
+            Learn more about terms and conditions
+          </Text>
+        </View>
+      </BlurView>
+    </View>
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3241,6 +3241,11 @@ expo-asset@~9.0.2:
     invariant "^2.2.4"
     md5-file "^3.2.3"
 
+expo-blur@~12.9.2:
+  version "12.9.2"
+  resolved "https://registry.yarnpkg.com/expo-blur/-/expo-blur-12.9.2.tgz#16d27c5d446fde0442d4f11d38b69611ca29f26b"
+  integrity sha512-q+EIOkXw7OCE3VBTLRANsUIdMxtFWDTFpaMulJEXMwtxNQaCcAvzHZvwWP9dlI96FM4A6UdX2/slBNfNJzJcCQ==
+
 expo-constants@~15.4.0:
   version "15.4.5"
   resolved "https://registry.yarnpkg.com/expo-constants/-/expo-constants-15.4.5.tgz#81756a4c4e1c020f840a419cd86a124a6d1fb35b"
@@ -3295,6 +3300,21 @@ expo-status-bar@~1.11.1:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/expo-status-bar/-/expo-status-bar-1.11.1.tgz#a11318741d361048c11db2b16c4364a79a74af30"
   integrity sha512-ddQEtCOgYHTLlFUe/yH67dDBIoct5VIULthyT3LRJbEwdpzAgueKsX2FYK02ldh440V87PWKCamh7R9evk1rrg==
+
+expo-symbols@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/expo-symbols/-/expo-symbols-0.1.4.tgz#b89a2ba5724406226063aa2bdeb9e6887cffda17"
+  integrity sha512-45y6uV/Uuhwji9HgwJg4YInZkDnT2ac0XGgfQJsSF9nN9kp/QgUy0fezJ53ecyuQp5+Asg6n3vSdIKD1/bamyw==
+  dependencies:
+    sf-symbols-typescript "^2.0.0"
+
+expo-system-ui@~2.9.4:
+  version "2.9.4"
+  resolved "https://registry.yarnpkg.com/expo-system-ui/-/expo-system-ui-2.9.4.tgz#f5f210805527e728f47edcd6a5aba3c1e83c9465"
+  integrity sha512-ExJ8AzEZjb/zbg6nRLrN/mqxWr6e4fAcT0LBN/YvPZljbMo23HU+/lPy0/YctF1tRRvQ3Z95ABSNjnx9ajQBjg==
+  dependencies:
+    "@react-native/normalize-color" "^2.0.0"
+    debug "^4.3.2"
 
 expo@^50.0.7:
   version "50.0.7"
@@ -5670,6 +5690,11 @@ setprototypeof@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
+
+sf-symbols-typescript@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/sf-symbols-typescript/-/sf-symbols-typescript-2.0.0.tgz#52548c84d124914faed1868c55bb71bffac472f1"
+  integrity sha512-Fc8Uhhl2plqXMw7GQ8q83t/zj1xhNCJvteDNJUDULaH/4a/Eqw5aW1UYEznyEIgkokw7QYXuQ9hOw8jhBLXL0A==
 
 shallow-clone@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
## Summary
In this feature, we explore how to integrate a bottom sheet view using just React Navigation. We tweak presentation options, combine custom styling with Expo Blur View, and achieve a beautiful final result. At the end, we discuss some limitations, alternatives, and best practices for this kind of sheet.


## YouTube
[Blur Bottom Sheet using React Navigation](https://youtu.be/kbA2rK9AxMk?si=Cgk1k3BP-3yRn084)

## Code with Beto
[Blur Bottom Sheet Project](https://codewithbeto.dev/projects/blurBottomSheetWithReactNavigation)

## Demo
![Simulator Screenshot - iPhone 15 - 2024-06-20 at 12 09 42](https://github.com/betomoedano/Budget-Buddy-App/assets/43630417/ca1d08b7-a4bc-404d-b820-ebb8ef2d97d8)
